### PR TITLE
Correct CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            py.test > test-reports/pytest.log
+            pytest > test-reports/pytest.log
 
       # Store test results.
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ jobs:
           name: install dependencies
           command: |
             python3 -m venv venv
-      #      . venv/bin/activate
+            . venv/bin/activate
+            pip install pytest
       #      pip install -r requirements.txt
       #
       #- save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,11 @@ jobs:
       #    # fallback to using the latest cache if no exact match is found
       #    - v1-dependencies-
       #
-      # - run:
-      #    name: install dependencies
-      #    command: |
-      #      python3 -m venv venv
+      # Create virtual environment.
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
       #      . venv/bin/activate
       #      pip install -r requirements.txt
       #


### PR DESCRIPTION
The config now runs flawlessly besides there are no tests, which makes pytest fail with the message `no tests ran in 0.00 seconds`.